### PR TITLE
Fix testFn signature in AsyncTest.

### DIFF
--- a/qunit.go
+++ b/qunit.go
@@ -185,7 +185,7 @@ func AsyncTestExpected(name string, expected interface{}, testFn func() interfac
 	})
 	return t
 }
-func AsyncTest(name string, testFn func() *js.Object) *js.Object {
+func AsyncTest(name string, testFn func() interface{}) *js.Object {
 	t := js.Global.Get("QUnit").Call("asyncTest", name, func() {
 		testFn()
 	})


### PR DESCRIPTION
Revert signature of testFn in AsyncTest to be consistent with others.
It looks like it was inadvertently changed in commit
3fc14b58aceef45e21f9cfbf649bcefbf9d82323.
