### PR TITLE
Remove unnecessary log statement in QUnitAssert.Equal

### DIFF
--- a/qunit.go
+++ b/qunit.go
@@ -62,7 +62,6 @@ func (qa QUnitAssert) DeepEqual(actual interface{}, expected interface{}, messag
 }
 
 func (qa QUnitAssert) Equal(actual interface{}, expected interface{}, message string) bool {
-	log("---> qunit: ", actual, expected, qa.Call("equal", actual, expected, message), qa.Call("equal", actual, expected, message).Bool())
 	return qa.Call("equal", actual, expected, message).Bool()
 }
 


### PR DESCRIPTION
This line was causing a pretty annoying bug. Since you call the equal method
two more times in the log statement, it causes Expect to fail and report extra
assertions.
