### PR TITLE
Add support for assert.async()

### DIFF
--- a/qunit.go
+++ b/qunit.go
@@ -97,6 +97,14 @@ func (qa QUnitAssert) Throws(block func() interface{}, message string) *js.Objec
 	return qa.Call("throws", block, message)
 }
 
+func (qa QUnitAssert) Async() func() {
+	// Use a closure to wrap around the async javascript object
+	asyncObj := qa.Call("async")
+	return func() {
+		asyncObj.Invoke()
+	}
+}
+
 //start QUnit static methods
 func Test(name string, testFn func(QUnitAssert)) {
 	js.Global.Get("QUnit").Call("test", name, func(e *js.Object) {


### PR DESCRIPTION
The testAsync method is [deprecated](https://api.qunitjs.com/QUnit.asyncTest/). The non-deprecated way to test asynchronous code is with [assert.async()](https://api.qunitjs.com/async/), which I've added support for. I didn't remove the deprecated method, so this shouldn't break anything.

Example usage:

``` go
qunit.Test("API Request", func(assert qunit.QUnitAssert) {
        qunit.Expect(2)
        // done is a function which should be called when the test is considered done
        done := assert.Async()
        go func() {
            res, err := http.Get("localhost:3000")
            assert.Ok(err == nil, "Request to API failed")
            assert.Equal(res.StatusCode, 200, fmt.Sprintf("Response had a non-200 status code. Got: %d", res.StatusCode))
            done()
        }()
    })
```

Cheers!
